### PR TITLE
Fix for failure to acquire audio lock

### DIFF
--- a/src/audio/ogc/SDL_ogcaudio.c
+++ b/src/audio/ogc/SDL_ogcaudio.c
@@ -234,6 +234,9 @@ static void OGCAUD_ThreadInit(_THIS)
 {
     /* Increase the priority of this audio thread by 1 to put it
        ahead of other SDL threads. */
+
+    LWP_SetThreadPriority(LWP_THREAD_NULL, LWP_PRIO_HIGHEST - 5);
+    
     (void)this;
 }
 


### PR DESCRIPTION
Maybe the Wii threading library expects every thread to declare a priority and becomes inconsistent if this doesn't happen?